### PR TITLE
[codex] migrate blog build to python

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ uv run build.py
 # Serve the generated site locally
 uv run python -m http.server 8000 --directory _site
 ```
+
+For local editing, use the dev server:
+
+```sh
+# Rebuild on file changes and serve _site/ on port 8000
+uv run dev.py
+```

--- a/dev.py
+++ b/dev.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import functools
+import http.server
+import os
+import threading
+import time
+from pathlib import Path
+
+import build
+
+
+ROOT = Path(__file__).parent
+WATCH_DIRS = [
+    ROOT / "_posts",
+    ROOT / "_drafts",
+    ROOT / "_data",
+    ROOT / "assets",
+]
+WATCH_FILES = [
+    ROOT / "build.py",
+    ROOT / "dev.py",
+    ROOT / "index.md",
+    ROOT / "blog.md",
+    ROOT / "talks.md",
+    ROOT / "bookshelf.md",
+    ROOT / "404.html",
+    ROOT / "README.md",
+    ROOT / "pyproject.toml",
+]
+POLL_INTERVAL_SECONDS = 1.0
+
+
+def snapshot() -> dict[Path, float]:
+    mtimes: dict[Path, float] = {}
+    for path in WATCH_FILES:
+        if path.exists():
+            mtimes[path] = path.stat().st_mtime
+    for directory in WATCH_DIRS:
+        if not directory.exists():
+            continue
+        for path in directory.rglob("*"):
+            if path.is_file():
+                mtimes[path] = path.stat().st_mtime
+    return mtimes
+
+
+def build_site() -> None:
+    build.main()
+    print("rebuilt _site")
+
+
+def watch() -> None:
+    last_seen = snapshot()
+    while True:
+        time.sleep(POLL_INTERVAL_SECONDS)
+        current = snapshot()
+        if current != last_seen:
+            build_site()
+            last_seen = current
+
+
+def main() -> None:
+    port = int(os.environ.get("PORT", "8000"))
+    build_site()
+
+    watcher = threading.Thread(target=watch, daemon=True)
+    watcher.start()
+
+    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=str(ROOT / "_site"))
+    with http.server.ThreadingHTTPServer(("127.0.0.1", port), handler) as httpd:
+        print(f"serving http://127.0.0.1:{port}")
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,3 @@ dependencies = [
     "pygments==2.19.2",
     "pyyaml==6.0.3",
 ]
-


### PR DESCRIPTION
## What changed

This PR migrates the site build from Jekyll/Ruby to a small Python static-site generator and adds a one-command local dev loop.

- added `build.py` to render posts, pages, feed output, and copy assets into `_site`
- switched project/deploy tooling to `uv` via `pyproject.toml` and `uv.lock`
- updated the GitHub Pages workflow to build with `uv`
- updated local run instructions to use `uv`
- added `dev.py` so local editing can rebuild on file changes while serving `_site`
- removed the old Jekyll/Ruby runtime files (`Gemfile`, `_config.yml`, `feed.xml`, etc.)
- removed the header/nav animation behavior on the portfolio and blog pages
- made standalone pages resolve cleanly both as `/bookshelf` and `/bookshelf.html` locally

## Why

The site was still using Jekyll and Ruby. The goal was to move it to a Python-based stack, keep the existing URLs stable, and make local iteration faster.

## Impact

- local development is now Python/`uv` based
- GitHub Pages no longer depends on Ruby/Jekyll
- post URLs remain in the same `/YYYY/MM/DD/slug.html` format
- `uv run dev.py` now rebuilds and serves the site in one command

## Validation

- `uv sync --locked`
- `uv run build.py`
- `uv run dev.py`
- local route checks for `/`, `/blog/`, `/talks/`, `/bookshelf`, representative post routes, `feed.xml`, and `404.html`
- content spot checks against the live site for `/blog/` and `2025/04/16/pytorch-needs-great-systems-engineers.html`
